### PR TITLE
Add underline animation and 4-side card outlines to Page9 About section

### DIFF
--- a/client/src/design/Page9.css
+++ b/client/src/design/Page9.css
@@ -42,23 +42,30 @@
 .highlight-ver::after {
   content: '';
   position: absolute;
-  bottom: 0;
+  bottom: -6px;
   left: 0;
   width: 0%;
   height: 4px;
   background-color: #ffc107;
   border-radius: 2px;
-  animation: underline-grow 1.2s ease-out forwards;
+  animation: underline-grow 1.2s cubic-bezier(0.77, 0, 0.175, 1) forwards;
 }
 
 @keyframes underline-grow {
-  from {
+  0% {
     width: 0%;
+    transform: translateX(0);
   }
-  to {
-    width: 120%;
+  80% {
+    width: 100%;
+    transform: translateX(0);
+  }
+  100% {
+    width: 100%;
+    transform: translateX(0);
   }
 }
+
 
 
 .team-photo {
@@ -90,4 +97,15 @@
 .section {
   background-color: #f9f9f9;
   padding: 4rem 0;
+}
+
+.card {
+  border: 2px solid transparent; 
+  transition: all 0.3s ease;
+}
+
+.card:hover {
+  border-color: #ffc107; 
+  transform: translateY(-5px);
+  box-shadow: 0 20px 30px rgba(0, 0, 0, 0.12);
 }

--- a/client/src/design/Page9.jsx
+++ b/client/src/design/Page9.jsx
@@ -4,7 +4,7 @@ import "./Page9.css";
 
 const Page9 = () => {
   return (
-    <div className="section">
+    <div className="section" id="about"> {/* <-- Added id here */}
       <div className="container">
         <div className="heading-wrapper text-center">
           <h2 className="heading">


### PR DESCRIPTION
- Added animated underline effect on Page9 about heading
- Added 4-side card outlines on hover effect
 -Linked about section with navigation bar
